### PR TITLE
cylinder

### DIFF
--- a/Scenes/cylinder.tscn
+++ b/Scenes/cylinder.tscn
@@ -4,48 +4,30 @@
 
 [node name="Cylinder" type="Control"]
 layout_mode = 3
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -554.0
-offset_top = 301.0
-offset_right = -554.0
-offset_bottom = 301.0
-grow_horizontal = 2
-grow_vertical = 2
+anchors_preset = 0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource("1_787um")
 
 [node name="Slots" type="VBoxContainer" parent="."]
 layout_mode = 1
-offset_top = -158.0
 offset_right = 50.0
-grow_vertical = 0
-metadata/_edit_use_anchors_ = true
+offset_bottom = 158.0
 
 [node name="Slot1" type="Label" parent="Slots"]
 layout_mode = 2
-text = "Empty	"
 
 [node name="Slot2" type="Label" parent="Slots"]
 layout_mode = 2
-text = "Empty	"
 
 [node name="Slot3" type="Label" parent="Slots"]
 layout_mode = 2
-text = "Empty	"
 
 [node name="Slot4" type="Label" parent="Slots"]
 layout_mode = 2
-text = "Empty	"
 
 [node name="Slot5" type="Label" parent="Slots"]
 layout_mode = 2
-text = "Empty	"
 
 [node name="Slot6" type="Label" parent="Slots"]
 layout_mode = 2
-text = "Empty	"

--- a/Scenes/cylinder.tscn
+++ b/Scenes/cylinder.tscn
@@ -1,33 +1,46 @@
 [gd_scene load_steps=2 format=3 uid="uid://db3v77bu7lukx"]
 
-[ext_resource type="Script" uid="uid://b6uiv1bnrvxl7" path="res://Scripts/Player/cylinder.gd" id="1_787um"]
+[ext_resource type="Script" uid="uid://cki60fb40qkxd" path="res://Scripts/Player/cylinder.gd" id="1_787um"]
 
 [node name="Cylinder" type="Control"]
 layout_mode = 3
-anchors_preset = 0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource("1_787um")
 
-[node name="Slots" type="VBoxContainer" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 1
-offset_right = 50.0
-offset_bottom = 158.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_bottom = 10
 
-[node name="Slot1" type="Label" parent="Slots"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+alignment = 2
+
+[node name="Slot1" type="Label" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Slot2" type="Label" parent="Slots"]
+[node name="Slot2" type="Label" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Slot3" type="Label" parent="Slots"]
+[node name="Slot3" type="Label" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Slot4" type="Label" parent="Slots"]
+[node name="Slot4" type="Label" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Slot5" type="Label" parent="Slots"]
+[node name="Slot5" type="Label" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Slot6" type="Label" parent="Slots"]
+[node name="Slot6" type="Label" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2

--- a/Scenes/cylinder.tscn
+++ b/Scenes/cylinder.tscn
@@ -1,0 +1,51 @@
+[gd_scene load_steps=2 format=3 uid="uid://db3v77bu7lukx"]
+
+[ext_resource type="Script" uid="uid://b6uiv1bnrvxl7" path="res://Scripts/Player/cylinder.gd" id="1_787um"]
+
+[node name="Cylinder" type="Control"]
+layout_mode = 3
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -554.0
+offset_top = 301.0
+offset_right = -554.0
+offset_bottom = 301.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("1_787um")
+
+[node name="Slots" type="VBoxContainer" parent="."]
+layout_mode = 1
+offset_top = -158.0
+offset_right = 50.0
+grow_vertical = 0
+metadata/_edit_use_anchors_ = true
+
+[node name="Slot1" type="Label" parent="Slots"]
+layout_mode = 2
+text = "Empty	"
+
+[node name="Slot2" type="Label" parent="Slots"]
+layout_mode = 2
+text = "Empty	"
+
+[node name="Slot3" type="Label" parent="Slots"]
+layout_mode = 2
+text = "Empty	"
+
+[node name="Slot4" type="Label" parent="Slots"]
+layout_mode = 2
+text = "Empty	"
+
+[node name="Slot5" type="Label" parent="Slots"]
+layout_mode = 2
+text = "Empty	"
+
+[node name="Slot6" type="Label" parent="Slots"]
+layout_mode = 2
+text = "Empty	"

--- a/Scenes/cylinder_upgrade.tscn
+++ b/Scenes/cylinder_upgrade.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=3 format=3 uid="uid://bbgt23eislljd"]
+
+[ext_resource type="Script" uid="uid://dnmsnugkfll2" path="res://Scripts/cylinder_upgrade.gd" id="1_jcxu8"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_3xget"]
+size = Vector2(32, 32)
+
+[node name="CylinderUpgrade" type="Area2D"]
+script = ExtResource("1_jcxu8")
+
+[node name="Polygon2D" type="Polygon2D" parent="."]
+color = Color(0.49411765, 1, 1, 1)
+polygon = PackedVector2Array(0, 0, 32, 0, 32, 32, 0, 32)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(16, 16)
+shape = SubResource("RectangleShape2D_3xget")
+
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -1,11 +1,12 @@
-[gd_scene load_steps=8 format=3 uid="uid://cywcer40qcjdc"]
+[gd_scene load_steps=9 format=3 uid="uid://cywcer40qcjdc"]
 
-[ext_resource type="Script" uid="uid://c7mt04lfrys5v" path="res://Scripts/Player/player.gd" id="1_v0iea"]
-[ext_resource type="Script" uid="uid://cqww0v2oy7w3c" path="res://Scripts/Player/States/idle.gd" id="2_fkybt"]
-[ext_resource type="Script" uid="uid://b7bvwfulqc7xe" path="res://Scripts/Player/States/move.gd" id="3_x3wgy"]
-[ext_resource type="Script" uid="uid://dqwynipt38kku" path="res://Scripts/Player/States/jump.gd" id="4_3smsa"]
-[ext_resource type="Script" uid="uid://drm820tb12vky" path="res://Scripts/Player/States/cast.gd" id="5_8erm5"]
+[ext_resource type="Script" uid="uid://lpae3t7xtxtg" path="res://Scripts/Player/player.gd" id="1_v0iea"]
+[ext_resource type="Script" uid="uid://igyj3vqcxh6a" path="res://Scripts/Player/States/idle.gd" id="2_fkybt"]
+[ext_resource type="Script" uid="uid://dkkbm4ewhoilw" path="res://Scripts/Player/States/move.gd" id="3_x3wgy"]
+[ext_resource type="Script" uid="uid://cfhj0vi7xltqb" path="res://Scripts/Player/States/jump.gd" id="4_3smsa"]
+[ext_resource type="Script" uid="uid://st6k3cp24ky4" path="res://Scripts/Player/States/cast.gd" id="5_8erm5"]
 [ext_resource type="PackedScene" uid="uid://li0xv5opve6i" path="res://Scenes/spellcast.tscn" id="6_x3wgy"]
+[ext_resource type="PackedScene" uid="uid://db3v77bu7lukx" path="res://Scenes/cylinder.tscn" id="7_3smsa"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_f60y1"]
 
@@ -32,5 +33,10 @@ script = ExtResource("4_3smsa")
 [node name="Cast" type="Node" parent="States"]
 script = ExtResource("5_8erm5")
 
+[node name="Cylinder" parent="." instance=ExtResource("7_3smsa")]
+
 [node name="Spellcast" parent="." instance=ExtResource("6_x3wgy")]
 visible = false
+size_flags_horizontal = 1
+size_flags_vertical = 1
+metadata/_edit_use_anchors_ = true

--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -1,10 +1,10 @@
 [gd_scene load_steps=9 format=3 uid="uid://cywcer40qcjdc"]
 
-[ext_resource type="Script" uid="uid://lpae3t7xtxtg" path="res://Scripts/Player/player.gd" id="1_v0iea"]
-[ext_resource type="Script" uid="uid://igyj3vqcxh6a" path="res://Scripts/Player/States/idle.gd" id="2_fkybt"]
-[ext_resource type="Script" uid="uid://dkkbm4ewhoilw" path="res://Scripts/Player/States/move.gd" id="3_x3wgy"]
-[ext_resource type="Script" uid="uid://cfhj0vi7xltqb" path="res://Scripts/Player/States/jump.gd" id="4_3smsa"]
-[ext_resource type="Script" uid="uid://st6k3cp24ky4" path="res://Scripts/Player/States/cast.gd" id="5_8erm5"]
+[ext_resource type="Script" uid="uid://c7mt04lfrys5v" path="res://Scripts/Player/player.gd" id="1_v0iea"]
+[ext_resource type="Script" uid="uid://cqww0v2oy7w3c" path="res://Scripts/Player/States/idle.gd" id="2_fkybt"]
+[ext_resource type="Script" uid="uid://b7bvwfulqc7xe" path="res://Scripts/Player/States/move.gd" id="3_x3wgy"]
+[ext_resource type="Script" uid="uid://dqwynipt38kku" path="res://Scripts/Player/States/jump.gd" id="4_3smsa"]
+[ext_resource type="Script" uid="uid://drm820tb12vky" path="res://Scripts/Player/States/cast.gd" id="5_8erm5"]
 [ext_resource type="PackedScene" uid="uid://li0xv5opve6i" path="res://Scenes/spellcast.tscn" id="6_x3wgy"]
 [ext_resource type="PackedScene" uid="uid://db3v77bu7lukx" path="res://Scenes/cylinder.tscn" id="7_3smsa"]
 
@@ -33,13 +33,13 @@ script = ExtResource("4_3smsa")
 [node name="Cast" type="Node" parent="States"]
 script = ExtResource("5_8erm5")
 
-[node name="Cylinder" parent="." instance=ExtResource("7_3smsa")]
-offset_left = 0.0
-offset_top = 0.0
-offset_right = 0.0
-offset_bottom = 0.0
+[node name="Camera2D" type="Camera2D" parent="."]
 
-[node name="Spellcast" parent="." instance=ExtResource("6_x3wgy")]
+[node name="CanvasLayer" type="CanvasLayer" parent="Camera2D"]
+
+[node name="Cylinder" parent="Camera2D/CanvasLayer" instance=ExtResource("7_3smsa")]
+
+[node name="Spellcast" parent="Camera2D/CanvasLayer" instance=ExtResource("6_x3wgy")]
 visible = false
 size_flags_horizontal = 1
 size_flags_vertical = 1

--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -34,6 +34,10 @@ script = ExtResource("4_3smsa")
 script = ExtResource("5_8erm5")
 
 [node name="Cylinder" parent="." instance=ExtResource("7_3smsa")]
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
 
 [node name="Spellcast" parent="." instance=ExtResource("6_x3wgy")]
 visible = false

--- a/Scenes/spellcast.tscn
+++ b/Scenes/spellcast.tscn
@@ -14,11 +14,3 @@ size_flags_vertical = 3
 script = ExtResource("1_2rayj")
 
 [node name="Glyph" type="Line2D" parent="."]
-
-[node name="Panel" type="Panel" parent="."]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2

--- a/Scenes/spellcast.tscn
+++ b/Scenes/spellcast.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://li0xv5opve6i"]
 
-[ext_resource type="Script" uid="uid://d3b1tk6g7vkhw" path="res://Scripts/Player/spellcast.gd" id="1_2rayj"]
+[ext_resource type="Script" uid="uid://c47wxv8yny2n2" path="res://Scripts/Player/spellcast.gd" id="1_2rayj"]
 
 [node name="Spellcast" type="Control"]
 layout_mode = 3
@@ -9,6 +9,16 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 script = ExtResource("1_2rayj")
 
 [node name="Glyph" type="Line2D" parent="."]
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2

--- a/Scenes/test_map.tscn
+++ b/Scenes/test_map.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=6 format=4 uid="uid://bgg5f6s52r6ib"]
+[gd_scene load_steps=7 format=4 uid="uid://bgg5f6s52r6ib"]
 
-[ext_resource type="Texture2D" uid="uid://d18db1mpe6v74" path="res://Assets/New Piskel.png" id="1_orl8w"]
+[ext_resource type="Texture2D" uid="uid://ciywcupi7jlol" path="res://Assets/New Piskel.png" id="1_orl8w"]
 [ext_resource type="PackedScene" uid="uid://cywcer40qcjdc" path="res://Scenes/player.tscn" id="2_8xpg0"]
 [ext_resource type="PackedScene" uid="uid://hnked78bqli5" path="res://Scenes/casting_table.tscn" id="3_8xpg0"]
+[ext_resource type="PackedScene" uid="uid://bbgt23eislljd" path="res://Scenes/cylinder_upgrade.tscn" id="4_gbc2j"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_gbc2j"]
 texture = ExtResource("1_orl8w")
@@ -24,3 +25,6 @@ position = Vector2(569, 324)
 
 [node name="CastingTable" parent="." instance=ExtResource("3_8xpg0")]
 position = Vector2(305, 416)
+
+[node name="CylinderUpgrade" parent="." instance=ExtResource("4_gbc2j")]
+position = Vector2(710, 396)

--- a/Scripts/Player/States/cast.gd
+++ b/Scripts/Player/States/cast.gd
@@ -6,7 +6,7 @@ var release: bool = false
 
 func _ready() -> void:
 	super()
-	spell = player.get_node("Spellcast")
+	spell = player.get_node("Camera2D/CanvasLayer/Spellcast")
 
 func enter() -> void:
 	player.sprite.modulate = Color8(0, 0, 255)

--- a/Scripts/Player/States/idle.gd
+++ b/Scripts/Player/States/idle.gd
@@ -5,6 +5,10 @@ func enter() -> void:
 	player.sprite.modulate = Color8(245, 245, 245)
 	player.velocity = Vector2.ZERO
 
+func process_frame(_delta: float) -> void:
+	if Input.is_action_just_pressed("spell"):
+		player.cylinder.cast()
+
 func process_state() -> State:
 	if Input.get_axis("left", "right"):
 		return player.states[1]

--- a/Scripts/Player/States/jump.gd
+++ b/Scripts/Player/States/jump.gd
@@ -8,6 +8,10 @@ func enter() -> void:
 	entry_y = player.position.y
 	player.velocity.y -= 500
 
+func process_frame(_delta: float) -> void:
+	if Input.is_action_just_pressed("spell"):
+		player.cylinder.cast()
+
 func process_phys(_delta: float) -> void:
 	var direction = Input.get_axis("left", "right")
 	player.velocity.x = direction * 200

--- a/Scripts/Player/States/move.gd
+++ b/Scripts/Player/States/move.gd
@@ -10,6 +10,10 @@ func enter() -> void:
 	player.sprite.modulate = Color8(255, 0, 0)
 	player.velocity.y = 0
 
+func process_frame(_delta: float) -> void:
+	if Input.is_action_just_pressed("spell"):
+		player.cylinder.cast()
+
 func process_phys(_delta: float) -> void:
 	direction = Input.get_axis("left", "right")
 	player.velocity.x = direction * speed

--- a/Scripts/Player/cylinder.gd
+++ b/Scripts/Player/cylinder.gd
@@ -7,14 +7,12 @@ var current_queue: PackedStringArray = []
 var queue_length: int = 1
 
 func _process(delta: float) -> void:
-	global_position = Vector2.ZERO
-
 	for i in queue_length:
-		var label: Label = get_node("Slots/Slot" + String.num_int64(i + 1))
+		var label: Label = get_node("MarginContainer/VBoxContainer/Slot" + String.num_int64(6 - i))
 		label.text = "Empty"
 
 	for i in current_queue.size():
-		var label: Label = get_node("Slots/Slot" + String.num_int64(i + 1))
+		var label: Label = get_node("MarginContainer/VBoxContainer/Slot" + String.num_int64(6 - i))
 		label.text = current_queue[i]
 
 func cast() -> void:

--- a/Scripts/Player/cylinder.gd
+++ b/Scripts/Player/cylinder.gd
@@ -9,6 +9,14 @@ var queue_length: int = 1
 func _process(delta: float) -> void:
 	global_position = Vector2.ZERO
 
+	for i in queue_length:
+		var label: Label = get_node("Slots/Slot" + String.num_int64(i + 1))
+		label.text = "Empty"
+
+	for i in current_queue.size():
+		var label: Label = get_node("Slots/Slot" + String.num_int64(i + 1))
+		label.text = current_queue[i]
+
 func cast() -> void:
 	if !current_queue.is_empty():
 		var spell: String = current_queue[0]

--- a/Scripts/Player/cylinder.gd
+++ b/Scripts/Player/cylinder.gd
@@ -1,0 +1,29 @@
+class_name Cylinder
+extends Control
+
+var current_queue: PackedStringArray = []
+
+@export
+var queue_length: int = 1
+
+func _process(delta: float) -> void:
+	global_position = Vector2.ZERO
+
+func cast() -> void:
+	if !current_queue.is_empty():
+		var spell: String = current_queue[0]
+		current_queue.remove_at(0)
+
+		print(spell)
+		print(current_queue)
+
+func add_to_queue(spell: String) -> void:
+	if current_queue.size() < queue_length:
+		current_queue.append(spell)
+	
+
+func empty_queue() -> void:
+	current_queue.clear()
+
+func grow_queue():
+	queue_length += 1

--- a/Scripts/Player/player.gd
+++ b/Scripts/Player/player.gd
@@ -10,7 +10,7 @@ var current_state: State = $States/Idle
 @onready
 var sprite: Polygon2D = $Polygon2D
 @onready
-var cylinder: Cylinder = $Cylinder
+var cylinder: Cylinder = $Camera2D/CanvasLayer/Cylinder
 
 var able_to_cast: bool = false
 

--- a/Scripts/Player/player.gd
+++ b/Scripts/Player/player.gd
@@ -9,6 +9,8 @@ var gravity: float = ProjectSettings.get_setting("physics/2d/default_gravity")
 var current_state: State = $States/Idle
 @onready
 var sprite: Polygon2D = $Polygon2D
+@onready
+var cylinder: Cylinder = $Cylinder
 
 var able_to_cast: bool = false
 

--- a/Scripts/Player/spellcast.gd
+++ b/Scripts/Player/spellcast.gd
@@ -4,7 +4,7 @@ extends Control
 @export
 var epsilon: float = 30.0
 @onready
-var player: Player = get_parent()
+var player: Player = get_parent().get_parent().get_parent()
 @onready 
 var line: Line2D = $Glyph
 
@@ -12,8 +12,6 @@ var line: Line2D = $Glyph
 var spells: Array = preload("res://Scripts/spells.json").data
 
 func _process(delta: float) -> void:
-	global_position = Vector2.ZERO
-
 	if visible:
 		if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
 			line.add_point(get_viewport().get_mouse_position())

--- a/Scripts/Player/spellcast.gd
+++ b/Scripts/Player/spellcast.gd
@@ -19,10 +19,10 @@ func _process(delta: float) -> void:
 			line.add_point(get_viewport().get_mouse_position())
 func cast() -> void:
 	print("Cast!")
-	var simple = simplify(line.get_points())
-	var angles = curve_to_anglesig(simple)
-	var spell = anglesig_match(angles)
-	print(spell)
+	var simple: PackedVector2Array = simplify(line.get_points())
+	var angles: PackedFloat64Array = curve_to_anglesig(simple)
+	var spell: String = anglesig_match(angles)
+	player.cylinder.add_to_queue(spell)
 	line.clear_points()
 
 func simplify(input: PackedVector2Array) -> PackedVector2Array:

--- a/Scripts/cylinder_upgrade.gd
+++ b/Scripts/cylinder_upgrade.gd
@@ -1,0 +1,7 @@
+extends Area2D
+
+func _on_body_entered(body: Node2D) -> void:
+	if body is Player:
+		var player: Player = body
+		player.cylinder.grow_queue()
+		queue_free()

--- a/project.godot
+++ b/project.godot
@@ -41,6 +41,11 @@ cast={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)
 ]
 }
+spell={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"location":0,"echo":false,"script":null)
+]
+}
 
 [rendering]
 


### PR DESCRIPTION
- **Added cylinder mechanic**
Spells are now queued to the cylinder, and cast with f.
- **Added cylinder upgrades**
Cylinder upgrades can be picked up, expanding the cylinder queue up to a maximum of 6.
- **Began work on UI for cylinder**
Added labels to show current number of cylinder slots, and what is queued in them.
- **Added UI to display current queue**
Added CanvasLayer and a MarginContainer to show the UI created in the previous commit in a static location in the bottom left corner.
