### PR TITLE
incorrect handler

### DIFF
--- a/Scripts/Player/cylinder.gd
+++ b/Scripts/Player/cylinder.gd
@@ -24,9 +24,14 @@ func cast() -> void:
 		print(current_queue)
 
 func add_to_queue(spell: String) -> void:
-	if current_queue.size() < queue_length:
-		if spell != "Incorrect":
+	if spell != "Incorrect":
+		current_queue.reverse()
+		if current_queue.size() < queue_length:
 			current_queue.append(spell)
+		elif current_queue.size() == queue_length:
+			current_queue.remove_at(0)
+			current_queue.append(spell)
+		current_queue.reverse()
 		
 
 func empty_queue() -> void:

--- a/Scripts/Player/cylinder.gd
+++ b/Scripts/Player/cylinder.gd
@@ -25,8 +25,9 @@ func cast() -> void:
 
 func add_to_queue(spell: String) -> void:
 	if current_queue.size() < queue_length:
-		current_queue.append(spell)
-	
+		if spell != "Incorrect":
+			current_queue.append(spell)
+		
 
 func empty_queue() -> void:
 	current_queue.clear()


### PR DESCRIPTION
- **Fixed incorrect spells being queued**
Glyphs that did not have a spell attached to them previously queued "Incorrect". They now do not.
- **Fixed queue to properly push old spells off when new ones exceed queue length**
Queue previously only accepted spells while there were free slots, and rejected new spells. They now remove the oldest queued spell and push the newest at the start.
